### PR TITLE
Add plumbing for SSL/TLS support

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -37,14 +37,18 @@
 extern "C" {
 #endif
 
+#include <sys/types.h>
+
 #ifdef  _WIN32
 #ifdef BUILDING_LIBRABBITMQ
 #define RABBITMQ_EXPORT extern __declspec(dllexport)
 #else
 #define RABBITMQ_EXPORT extern __declspec(dllimport)
 #endif
+struct iovec;
 #else
 #define RABBITMQ_EXPORT extern
+#include <sys/uio.h>
 #endif
 
 typedef int amqp_boolean_t;
@@ -220,6 +224,13 @@ typedef enum amqp_sasl_method_enum_ {
 /* Opaque struct. */
 typedef struct amqp_connection_state_t_ *amqp_connection_state_t;
 
+/* Socket callbacks. */
+typedef ssize_t (*amqp_socket_writev_fn)(int, const struct iovec *, int, void *);
+typedef ssize_t (*amqp_socket_send_fn)(int, const void *, size_t, int, void *);
+typedef ssize_t (*amqp_socket_recv_fn)(int, void *, size_t, int, void *);
+typedef int (*amqp_socket_close_fn)(int, void *);
+typedef int (*amqp_socket_error_fn)(void *);
+
 RABBITMQ_EXPORT char const *amqp_version(void);
 
 /* Exported empty data structures */
@@ -250,6 +261,14 @@ RABBITMQ_EXPORT amqp_connection_state_t amqp_new_connection(void);
 RABBITMQ_EXPORT int amqp_get_sockfd(amqp_connection_state_t state);
 RABBITMQ_EXPORT void amqp_set_sockfd(amqp_connection_state_t state,
 				     int sockfd);
+RABBITMQ_EXPORT void
+amqp_set_sockfd_full(amqp_connection_state_t state, int sockfd,
+		     amqp_socket_writev_fn writev_fn,
+		     amqp_socket_send_fn send_fn,
+		     amqp_socket_recv_fn recv_fn,
+		     amqp_socket_close_fn close_fn,
+		     amqp_socket_error_fn error_fn,
+		     void *user_data);
 RABBITMQ_EXPORT int amqp_tune_connection(amqp_connection_state_t state,
 					 int channel_max,
 					 int frame_max,

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -54,6 +54,18 @@
                 _check_state->state);                                   \
   }
 
+static ssize_t amqp_socket_send(int sockfd, const void *buf, size_t len,
+				int flags, AMQP_UNUSED void *user_data)
+{
+  return send(sockfd, buf, len, flags);
+}
+
+static ssize_t amqp_socket_recv(int sockfd, void *buf, size_t len, int flags,
+				AMQP_UNUSED void *user_data)
+{
+  return recv(sockfd, buf, len, flags);
+}
+
 amqp_connection_state_t amqp_new_connection(void) {
   amqp_connection_state_t state =
     (amqp_connection_state_t) calloc(1, sizeof(struct amqp_connection_state_t_));
@@ -100,6 +112,29 @@ void amqp_set_sockfd(amqp_connection_state_t state,
 		     int sockfd)
 {
   state->sockfd = sockfd;
+  state->writev = amqp_socket_writev;
+  state->send = amqp_socket_send;
+  state->recv = amqp_socket_recv;
+  state->close = amqp_socket_close;
+  state->error = amqp_socket_error;
+  state->user_data = NULL;
+}
+
+void amqp_set_sockfd_full(amqp_connection_state_t state, int sockfd,
+			  amqp_socket_writev_fn writev_fn,
+			  amqp_socket_send_fn send_fn,
+			  amqp_socket_recv_fn recv_fn,
+			  amqp_socket_close_fn close_fn,
+			  amqp_socket_error_fn error_fn,
+			  void *user_data)
+{
+  state->sockfd = sockfd;
+  state->writev = writev_fn;
+  state->send = send_fn;
+  state->recv = recv_fn;
+  state->close = close_fn;
+  state->error = error_fn;
+  state->user_data = user_data;
 }
 
 int amqp_tune_connection(amqp_connection_state_t state,
@@ -135,18 +170,17 @@ int amqp_get_channel_max(amqp_connection_state_t state) {
 }
 
 int amqp_destroy_connection(amqp_connection_state_t state) {
-  int s = state->sockfd;
-
-  empty_amqp_pool(&state->frame_pool);
-  empty_amqp_pool(&state->decoding_pool);
-  free(state->outbound_buffer.bytes);
-  free(state->sock_inbound_buffer.bytes);
-  free(state);
-
-  if (s >= 0 && amqp_socket_close(s) < 0)
-    return -amqp_socket_error();
-  else
-    return 0;
+  int status = 0;
+  if (state) {
+    empty_amqp_pool(&state->frame_pool);
+    empty_amqp_pool(&state->decoding_pool);
+    free(state->outbound_buffer.bytes);
+    free(state->sock_inbound_buffer.bytes);
+    if (state->sockfd >= 0 && state->close(state->sockfd, state->user_data) < 0)
+      status = -state->error(state->user_data);
+    free(state);
+  }
+  return status;
 }
 
 static void return_to_idle(amqp_connection_state_t state) {
@@ -360,7 +394,7 @@ int amqp_send_frame(amqp_connection_state_t state,
     iov[2].iov_base = &frame_end_byte;
     iov[2].iov_len = FOOTER_SIZE;
 
-    res = amqp_socket_writev(state->sockfd, iov, 3);
+    res = state->writev(state->sockfd, iov, 3, state->user_data);
   }
   else {
     size_t out_frame_len;
@@ -407,12 +441,13 @@ int amqp_send_frame(amqp_connection_state_t state,
 
     amqp_e32(out_frame, 3, out_frame_len);
     amqp_e8(out_frame, out_frame_len + HEADER_SIZE, AMQP_FRAME_END);
-    res = send(state->sockfd, out_frame,
-               out_frame_len + HEADER_SIZE + FOOTER_SIZE, 0);
+    res = state->send(state->sockfd, out_frame,
+                      out_frame_len + HEADER_SIZE + FOOTER_SIZE,
+                      0, state->user_data);
   }
 
   if (res < 0)
-    return -amqp_socket_error();
+    return -state->error(state->user_data);
   else
     return 0;
 }

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -34,6 +34,7 @@
  */
 
 #include "config.h"
+#include "amqp.h"
 
 /* Error numbering: Because of differences in error numbering on
  * different platforms, we want to keep error numbers opaque for
@@ -56,6 +57,21 @@
 #define ERROR_CONNECTION_CLOSED 7
 #define ERROR_BAD_AMQP_URL 8
 #define ERROR_MAX 8
+
+/* GCC attributes */
+#if __GNUC__ > 2 | (__GNUC__ == 2 && __GNUC_MINOR__ > 4)
+#define AMQP_UNUSED \
+  __attribute__ ((__unused__))
+#else
+#define AMQP_UNUSED
+#endif
+
+#if __GNUC__ >= 4
+#define AMQP_PRIVATE \
+  __attribute__ ((visibility ("hidden")))
+#else
+#define AMQP_PRIVATE
+#endif
 
 extern char *amqp_os_error_string(int err);
 
@@ -118,6 +134,13 @@ struct amqp_connection_state_t_ {
   amqp_bytes_t outbound_buffer;
 
   int sockfd;
+  amqp_socket_writev_fn writev;
+  amqp_socket_send_fn send;
+  amqp_socket_recv_fn recv;
+  amqp_socket_close_fn close;
+  amqp_socket_error_fn error;
+  void *user_data;
+
   amqp_bytes_t sock_inbound_buffer;
   size_t sock_inbound_offset;
   size_t sock_inbound_limit;

--- a/librabbitmq/unix/socket.c
+++ b/librabbitmq/unix/socket.c
@@ -32,8 +32,8 @@
 
 #include "config.h"
 
+#include <errno.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdint.h>
@@ -44,6 +44,7 @@
 #include "amqp_private.h"
 #include "socket.h"
 
+AMQP_PRIVATE
 int amqp_socket_socket(int domain, int type, int proto)
 {
 	int flags;
@@ -65,7 +66,27 @@ int amqp_socket_socket(int domain, int type, int proto)
 	return s;
 }
 
+AMQP_PRIVATE
 char *amqp_os_error_string(int err)
 {
 	return strdup(strerror(err));
+}
+
+AMQP_PRIVATE
+int amqp_socket_close(int sockfd, AMQP_UNUSED void *user_data)
+{
+	return close(sockfd);
+}
+
+AMQP_PRIVATE
+int amqp_socket_writev(int sockfd, const struct iovec *iov,
+		       int iovcnt, AMQP_UNUSED void *user_data)
+{
+	return writev(sockfd, iov, iovcnt);
+}
+
+AMQP_PRIVATE
+int amqp_socket_error(AMQP_UNUSED void *user_data)
+{
+	return errno | ERROR_CATEGORY_OS;
 }

--- a/librabbitmq/unix/socket.h
+++ b/librabbitmq/unix/socket.h
@@ -33,29 +33,22 @@
  * ***** END LICENSE BLOCK *****
  */
 
-#include <errno.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/uio.h>
-#include <sys/socket.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
 
 static inline int amqp_socket_init(void)
 {
 	return 0;
 }
 
-extern int amqp_socket_socket(int domain, int type, int proto);
-
+int amqp_socket_socket(int domain, int type, int proto);
+int amqp_socket_close(int sockfd, AMQP_UNUSED void *user_data);
+int amqp_socket_writev(int sockfd, const struct iovec *iov, int iovcnt,
+		       void *user_data);
+int amqp_socket_error(void *user_data);
 #define amqp_socket_setsockopt setsockopt
-#define amqp_socket_close close
-#define amqp_socket_writev writev
-
-static inline int amqp_socket_error()
-{
-	return errno | ERROR_CATEGORY_OS;
-}
 
 #endif

--- a/librabbitmq/windows/socket.c
+++ b/librabbitmq/windows/socket.c
@@ -45,6 +45,7 @@
 
 static int called_wsastartup;
 
+AMQP_PRIVATE
 int amqp_socket_init(void)
 {
 	if (!called_wsastartup) {
@@ -59,6 +60,7 @@ int amqp_socket_init(void)
 	return 0;
 }
 
+AMQP_PRIVATE
 char *amqp_os_error_string(int err)
 {
 	char *msg, *copy;
@@ -73,4 +75,27 @@ char *amqp_os_error_string(int err)
 	copy = strdup(msg);
 	LocalFree(msg);
 	return copy;
+}
+
+AMQP_PRIVATE
+int amqp_socket_close(int sockfd, AMQP_UNUSED void *user_data)
+{
+	return closesocket(sockfd);
+}
+
+AMQP_PRIVATE
+int amqp_socket_writev(int sock, struct iovec *iov, int nvecs,
+		       AMQP_UNUSED void *user_data)
+{
+	DWORD ret;
+	if (WSASend(sock, (LPWSABUF)iov, nvecs, &ret, 0, NULL, NULL) == 0)
+		return ret;
+	else
+		return -1;
+}
+
+AMQP_PRIVATE
+int amqp_socket_error(AMQP_UNUSED void *user_data)
+{
+	return WSAGetLastError() | ERROR_CATEGORY_OS;
 }

--- a/librabbitmq/windows/socket.h
+++ b/librabbitmq/windows/socket.h
@@ -33,20 +33,8 @@
  * ***** END LICENSE BLOCK *****
  */
 
+#include "amqp_private.h"
 #include <winsock2.h>
-
-extern int amqp_socket_init(void);
-
-#define amqp_socket_socket socket
-#define amqp_socket_close closesocket
-
-static inline int amqp_socket_setsockopt(int sock, int level, int optname,
-                                    const void *optval, size_t optlen)
-{
-        /* the winsock setsockopt function has its 4th argument as a
-           const char * */
-        return setsockopt(sock, level, optname, (const char *)optval, optlen);
-}
 
 /* same as WSABUF */
 struct iovec {
@@ -54,18 +42,19 @@ struct iovec {
 	void *iov_base;
 };
 
-static inline int amqp_socket_writev(int sock, struct iovec *iov, int nvecs)
-{
-	DWORD ret;
-	if (WSASend(sock, (LPWSABUF)iov, nvecs, &ret, 0, NULL, NULL) == 0)
-		return ret;
-	else
-		return -1;
-}
+int amqp_socket_init(void);
+int amqp_socket_close(int sockfd, AMQP_UNUSED void *user_data);
+int amqp_socket_writev(int sock, struct iovec *iov, int nvecs,
+		       AMQP_UNUSED void *user_data);
+static inline int amqp_socket_error();
+#define amqp_socket_socket socket
 
-static inline int amqp_socket_error()
+static inline int amqp_socket_setsockopt(int sock, int level, int optname,
+                                    const void *optval, size_t optlen)
 {
-	return WSAGetLastError() | ERROR_CATEGORY_OS;
+        /* the winsock setsockopt function has its 4th argument as a
+           const char * */
+        return setsockopt(sock, level, optname, (const char *)optval, optlen);
 }
 
 #endif


### PR DESCRIPTION
This change abstracts out the networking functions so that the user can provide an SSL/TLS implementation. Below is an explanation of the changes included.
### SSL/TLS plumbing

Callback functions replace `writev()`, `send()`, and `recv()` (there is also a callback for error reporting). The default interface remains unchanged. If the user wants to create a SSL/TLS connection they first negotiate the connection and then use the new function `amqp_set_sockfd_full()` to provide the networking implementation for their SSL/TLS library. The user may provide an optional pointer to data that is passed through to the networking functions.

I'm still running tests but I thought I would submit it early to get some feedback. The coding style seems a bit variable so I tried to follow the surrounding code in each file.
